### PR TITLE
Random Seed: Add the ability to generate a random seed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Where
 - "lx_filename": path to lx logical matrix alist file. Only necessary if "logical_check_method" is set to "lx" 
 - "code_label": whatever you like
 -  "logical_check_method": "hz" or "lx". See notes below.
-- "input_seed": the input seed for the Mersenne twister random number generator
+- "input_seed": the input seed for the Mersenne twister random number generator. Note if >0 that seed is used, otherwise the seed is generated from the current time.
 - "bit_error_rate": the bit error rate
 - "target_runs": the number of runs you would like to simulate
 - "osd_order": the osd order parameter

--- a/sim_scripts/bp_osd_decode.cpp
+++ b/sim_scripts/bp_osd_decode.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <string>
 #include <sstream>
+#include <ctime>
 
 #include "bp_osd_c.hpp"
 using namespace std;
@@ -36,11 +37,11 @@ int main(int argc, char *argv[])
 //    };
 
     //timing functions setup
-    timing time;
-    cout<<"Start time: "<<time.start_time_string<<endl;
+    timing simtime;
+    cout<<"Start time: "<<simtime.start_time_string<<endl;
     cout<<"Input file: "<<argv[1]<<endl;
     int elapsed_seconds;
-    elapsed_seconds=time.elapsed_time_seconds();
+    elapsed_seconds=simtime.elapsed_time_seconds();
 
     //read in json input file
     ifstream json_input_file(argv[1]);
@@ -52,15 +53,20 @@ int main(int argc, char *argv[])
     //get input file from command line arguments
     output["input_file"]=argv[1];
 
-    //setup random number generator
+    //setup random number generator. If seed is <=0 then use current time for seed.
     int random_seed = json_read_safe(output,"input_seed");
+    if (random_seed <= 0) {
+      time_t now = time(0);
+      random_seed = (int)now;
+    }
     MTRand r=setup_mtwister_rng(random_seed);
+    output["seed"]=random_seed;
 
     //save start time
-    output["start_time"] = time.start_time_string;
+    output["start_time"] = simtime.start_time_string;
 
     //generate UI from start time + random seed
-    unsigned long long int ui =time.start_time_seconds+random_seed;
+    unsigned long long int ui =simtime.start_time_seconds+random_seed;
     output["ui"]=ui;
 
     //read in sim parameters
@@ -240,14 +246,14 @@ int main(int argc, char *argv[])
 
 
         //write to output every 3 seconds. Change this as you see fit
-        if((time.elapsed_time_seconds()-elapsed_seconds>3) | (run_count==target_runs) ){
+        if((simtime.elapsed_time_seconds()-elapsed_seconds>3) | (run_count==target_runs) ){
 
             //calculate logical error rates
             osdw_ler= 1.0 - osdw_success_count / (double(run_count));
             osd0_ler= 1.0 - osd0_success_count / (double(run_count));
             bp_ler= 1.0 - bp_success_count / (double(run_count));
 
-            elapsed_seconds=time.elapsed_time_seconds();
+            elapsed_seconds=simtime.elapsed_time_seconds();
 
             output["run_count"] = run_count;
             output["osdw_success_count"]=osdw_success_count;
@@ -257,8 +263,8 @@ int main(int argc, char *argv[])
             output["osdw_ler"] = osdw_ler;
             output["osd0_ler"] = osd0_ler;
             output["bp_ler"] = bp_ler;
-            output["runtime_seconds"] = time.elapsed_time_seconds();
-            output["runtime_readable"] = time.elapsed_time_readable();
+            output["runtime_seconds"] = simtime.elapsed_time_seconds();
+            output["runtime_readable"] = simtime.elapsed_time_readable();
             cout << "Runs: " << run_count << "; OSDW_LER: " << osdw_ler << "; OSD0_LER: " << osd0_ler << "; BP_LER: " << bp_ler << "; Runtime: " << output["runtime_readable"] << endl;
 
             //command line output


### PR DESCRIPTION
It is useful to be able to seed the RNG with a seed that is based on
the current time. This ensures different simulations generate
different results. However simulating with a known seed is also
useful.

This commit will use an input seed if that seed is >0. Otherwise it
will generate a seed based on the current system time. In all cases
the seed used is written to the output file.

Fixes #10.