### PR TITLE
Iteration Log. Logging iteration depth statistics

### DIFF
--- a/sim_scripts/bp_osd_decode.cpp
+++ b/sim_scripts/bp_osd_decode.cpp
@@ -183,8 +183,9 @@ int main(int argc, char *argv[])
     double osdw_ler;
     double osd0_ler;
     double bp_ler;
-
-
+    double average_iterations_before_converge=-1;
+    int min_iterations_before_converge=hx_n;
+    int max_iterations_before_converge=-1;
 
     //MAIN SIM LOOP
 
@@ -234,6 +235,22 @@ int main(int argc, char *argv[])
             if (*hx_bp_osd.converge == 1) {
                 bp_converge_count++;
 
+		if (*hx_bp_osd.iter>max_iterations_before_converge){
+                    max_iterations_before_converge=*hx_bp_osd.iter+1;
+                }
+
+                if (*hx_bp_osd.iter<min_iterations_before_converge){
+                    min_iterations_before_converge=*hx_bp_osd.iter+1;
+                }
+
+                if (average_iterations_before_converge==-1){
+                    average_iterations_before_converge=*hx_bp_osd.iter+1;
+                }
+                else{
+
+                    average_iterations_before_converge=((bp_converge_count-1)*average_iterations_before_converge+*hx_bp_osd.iter+1)/bp_converge_count;
+                }
+
                 if (logical_check_method=="lx") {
                     logical_error = check_logical_error_lx(lx, bit_error, hx_bp_osd.bp_decoding);
                 } else {
@@ -265,7 +282,12 @@ int main(int argc, char *argv[])
             output["bp_ler"] = bp_ler;
             output["runtime_seconds"] = simtime.elapsed_time_seconds();
             output["runtime_readable"] = simtime.elapsed_time_readable();
-            cout << "Runs: " << run_count << "; OSDW_LER: " << osdw_ler << "; OSD0_LER: " << osd0_ler << "; BP_LER: " << bp_ler << "; Runtime: " << output["runtime_readable"] << endl;
+            output["max_iterations_before_converge"]=max_iterations_before_converge;
+            output["min_iterations_before_converge"]=min_iterations_before_converge;
+            output["average_iterations_before_converge"]=average_iterations_before_converge;
+            cout << "Runs: " << run_count << "; OSDW_LER: " << osdw_ler << "; OSD0_LER: " << osd0_ler << "; BP_LER: " << bp_ler << "; Iter. (min/avg/max)" << min_iterations_before_converge << "/"
+		 << average_iterations_before_converge << "/" << max_iterations_before_converge <<
+	      "; Runtime: " << output["runtime_readable"] << endl;
 
             //command line output
             ofstream output_file(output_filename.str(),ofstream::trunc);


### PR DESCRIPTION
In LDPC BP decoding it is useful to track the minimum, average and
maximum iteration counts. This commit adds that to both the output
results file and the stdout dump.

Fixes #9.