### PR TITLE
Use raw-strings for invalid escape sequences

### DIFF
--- a/src/bposd/css.py
+++ b/src/bposd/css.py
@@ -159,15 +159,15 @@ class css_code:
             assert not np.any((self.hz @ self.lx.T).data % 2)
         except AssertionError:
             valid_code = False
-            print(" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
+            print(r" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
 
         try:
             assert not np.any((self.hx @ self.lz.T).data % 2)
             if show_tests:
-                print(" -lx \in ker{hz} AND lz \in ker{hx}: Pass")
+                print(r" -lx \in ker{hz} AND lz \in ker{hx}: Pass")
         except AssertionError:
             valid_code = False
-            print(" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
+            print(r" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
 
         # if show_tests and valid_code: print("\t-lx \in ker{hz} AND lz \in ker{hx}: Pass")
 

--- a/src/bposd/stab.py
+++ b/src/bposd/stab.py
@@ -134,10 +134,10 @@ class stab_code:
             assert ((self.hx @ self.lz.T + self.hz @ self.lx.T).data % 2).any() == 0
         except AssertionError:
             valid_code = False
-            print(" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
+            print(r" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
 
         if show_tests and valid_code:
-            print("\t-lx \in ker{hz} AND lz \in ker{hx}: Pass")
+            print(r"\t-lx \in ker{hz} AND lz \in ker{hx}: Pass")
 
         try:
             lx_lz = self.lx @ self.lz.T + self.lz @ self.lx.T


### PR DESCRIPTION
This PR fixes #19 by using raw-strings instead of normal strings.

I checked that it covers all occurrences of invalid escape sequences with
```sh
find . -name "*.py" -exec grep '\\' {} +
```
which prints
```
./src/bposd/css_decode_sim.py:                        "\nTarget error bar precision reached. Stopping simulation..."
./src/bposd/css.py:            # lz\in ker{hx} AND \notin Im(Hz.T)
./src/bposd/css.py:        # if show_tests and valid_code: print("\t-PCMs commute hx@hz.T == hz@hx.T ==0: Pass")
./src/bposd/css.py:            print(r" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
./src/bposd/css.py:                print(r" -lx \in ker{hz} AND lz \in ker{hx}: Pass")
./src/bposd/css.py:            print(r" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
./src/bposd/css.py:        # if show_tests and valid_code: print("\t-lx \in ker{hz} AND lz \in ker{hx}: Pass")
./src/bposd/css.py:        # if show_tests and valid_code: print("\t- lx and lz anitcommute: Pass")
./src/bposd/stab.py:        # if show_tests and valid_code: print("\t-PCMs commute hx@hz.T == hz@hx.T ==0: Pass")
./src/bposd/stab.py:            print(r" -lx \in ker{hz} AND lz \in ker{hx}: Fail")
./src/bposd/stab.py:            print(r"\t-lx \in ker{hz} AND lz \in ker{hx}: Pass")
./src/bposd/stab.py:        # if show_tests and valid_code: print("\t- lx and lz anitcommute: Pass")
```
All occurrences of invalid escape sequences are either in comments (which is fine) or in raw-strings now.

I also checked locally that the commands used in CI jobs mentioned in #19 are passing fine with raw-strings.

Finally, raw strings have been introduced even before Python 3.0, and so should not change the minimum supported Python version of 3.9 for this package.